### PR TITLE
make Get(int length) virtual to facilitate mocking in tests

### DIFF
--- a/src/RandomStringCreator/StringCreator.cs
+++ b/src/RandomStringCreator/StringCreator.cs
@@ -33,7 +33,7 @@
             this.lazyByteProvider = new Lazy<RandomByteProvider>(() => new RandomByteProvider(bufferLength));
         }
 
-        public string Get(int length)
+        public virtual string Get(int length)
         {
             var chars = this.GetChars(length);
             return new string(chars);


### PR DESCRIPTION
unit tests should preferably be deterministic, and I had a case where I wanted to validate the id string generated was use properly, which currently is hard since you are not able to mock out the method using a mocking framework such as FakeItEasy